### PR TITLE
Remove need for running in privileged mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Now simply mount the configuration file and run! For example, if your configurat
 
 ```bash
 docker run --name wireguard                                          \
-    --privileged                                                     \
+    --cap-add NET_ADMIN                                              \
+    --cap-add SYS_MODULE                                             \
+    --sysctl net.ipv4.conf.all.src_valid_mark=1                      \
     -v /path/to/conf/mullvad.conf:/etc/wireguard/mullvad.conf        \
     jordanpotter/wireguard
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,12 @@ fi
 config=`echo $configs | head -n 1`
 interface="${config%.*}"
 
+if [[ "$(cat /proc/sys/net/ipv4/conf/all/src_valid_mark)" != "1" ]]; then
+    echo "sysctl net.ipv4.conf.all.src_valid_mark=1 is not set" >&2
+    exit 1
+fi
+
+sed -i "s:sysctl -q net.ipv4.conf.all.src_valid_mark=1:echo skipping setting net.ipv4.conf.all.src_valid_mark:" /usr/bin/wg-quick
 wg-quick up $interface
 
 docker_network="$(ip -o addr show dev eth0 | awk '$3 == "inet" {print $4}')"


### PR DESCRIPTION
To remove the need for running privileged mode, set the necessary
`net.ipv4.conf.all.src_valid_mark=1` sysctl via docker and modify the
`/usr/bin/wg-quick` script from setting the sysctl

* Set `net.ipv4.conf.all.src_valid_mark=1` sysctl via docker `--sysctl`

* Set CAPs of NET_ADMIN and SYS_MODULE instead of using`--privileged`.

* Check that `net.ipv4.conf.all.src_valid_mark=1` is set in entrypoint
  script

Fixes #2