### PR TITLE
Remove apt cache and skip recommended packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y openresolv iptables iproute2 wireguard
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openresolv iptables iproute2 wireguard \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This reduces the layer size from 367MiB to 178MiB.

BEFORE:

```
$ docker history ea2d6da4cbdc
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
ea2d6da4cbdc        27 seconds ago      /bin/sh -c #(nop)  ENTRYPOINT ["/entrypoint.…   0B
2c7e3f0de3c8        27 seconds ago      /bin/sh -c #(nop) COPY file:ad76fe44d1402628…   1.44kB
1a29ca960363        29 seconds ago      /bin/sh -c apt-get update && apt-get install…   367MB
f643c72bc252        12 days ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>           12 days ago         /bin/sh -c mkdir -p /run/systemd && echo 'do…   7B
<missing>           12 days ago         /bin/sh -c [ -z "$(apt-get indextargets)" ]     0B
<missing>           12 days ago         /bin/sh -c set -xe   && echo '#!/bin/sh' > /…   811B
<missing>           12 days ago         /bin/sh -c #(nop) ADD file:4f15c4475fbafb3fe…   72.9MB
```

AFTER:
```
$ docker history c96da58d5a74
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
c96da58d5a74        5 seconds ago       /bin/sh -c #(nop)  ENTRYPOINT ["/entrypoint.…   0B
b821a8d478a9        5 seconds ago       /bin/sh -c #(nop) COPY file:ad76fe44d1402628…   1.44kB
ac4b2f30261d        5 seconds ago       /bin/sh -c apt-get update  && apt-get instal…   178MB
f643c72bc252        12 days ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>           12 days ago         /bin/sh -c mkdir -p /run/systemd && echo 'do…   7B
<missing>           12 days ago         /bin/sh -c [ -z "$(apt-get indextargets)" ]     0B
<missing>           12 days ago         /bin/sh -c set -xe   && echo '#!/bin/sh' > /…   811B
<missing>           12 days ago         /bin/sh -c #(nop) ADD file:4f15c4475fbafb3fe…   72.9MB
```