### PR TITLE
Switch base image from Ubuntu to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:20.04
+FROM alpine:3.12.1
 
-RUN apt-get update && apt-get install -y openresolv iptables iproute2 wireguard
+RUN apk add --no-cache \
+      openresolv iptables iproute2 wireguard-tools \
+      findutils # Needed for find's -printf flag.
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This dramatically reduces the size of the container from hundreds of MiBs to just over ten.

BEFORE
```
$ docker history ea2d6da4cbdc
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
ea2d6da4cbdc        27 seconds ago      /bin/sh -c #(nop)  ENTRYPOINT ["/entrypoint.…   0B
2c7e3f0de3c8        27 seconds ago      /bin/sh -c #(nop) COPY file:ad76fe44d1402628…   1.44kB
1a29ca960363        29 seconds ago      /bin/sh -c apt-get update && apt-get install…   367MB
f643c72bc252        12 days ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>           12 days ago         /bin/sh -c mkdir -p /run/systemd && echo 'do…   7B
<missing>           12 days ago         /bin/sh -c [ -z "$(apt-get indextargets)" ]     0B
<missing>           12 days ago         /bin/sh -c set -xe   && echo '#!/bin/sh' > /…   811B
<missing>           12 days ago         /bin/sh -c #(nop) ADD file:4f15c4475fbafb3fe…   72.9MB
```

AFTER
```
$ docker history 6b71b07e8ccd
IMAGE               CREATED              CREATED BY                                      SIZE                COMMENT
6b71b07e8ccd        About a minute ago   /bin/sh -c #(nop)  ENTRYPOINT ["/entrypoint.…   0B
898dbb77c8ce        About a minute ago   /bin/sh -c #(nop) COPY file:ad76fe44d1402628…   1.44kB
8470d1ebb9cb        About a minute ago   /bin/sh -c apk add --no-cache       openreso…   7.37MB
d6e46aa2470d        6 weeks ago          /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>           6 weeks ago          /bin/sh -c #(nop) ADD file:f17f65714f703db90…   5.57MB
```

I have tested this change by running
```
$ docker run -it --rm --net=container:wireguard-alpine appropriate/curl http://httpbin.org/ip
```
which succeeds. I don't really know how to test it beyond that.

# This is a breaking change

If you consider that your container may have been used a base image, this is a breaking change. Consumers will no longer have access to software from the Ubuntu image and apt-get to install packages.

As a result, it should probably be tagged 2.0.0.

This PR obsoletes #8. 