### PR TITLE
Install ip6tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.12.1
 
 RUN apk add --no-cache \
-      openresolv iptables iproute2 wireguard-tools \
+      openresolv iptables ip6tables iproute2 wireguard-tools \
       findutils # Needed for find's -printf flag.
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Fixes https://github.com/jordanpotter/docker-wireguard/issues/11

I also had to add -v "/lib/modules:/lib/modules"