### PR TITLE
Change network_mode to work in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ services:
   curl:
     image: appropriate/curl
     command: http://httpbin.org/ip
-    network_mode: container:wireguard
+    network_mode: service:wireguard
     depends_on:
       - wireguard
 ```


### PR DESCRIPTION
Inside a docker-compose file, network mode should be `service:wireguard` not `container:wireguard` in order to function properly
The error that lead me to this was `Service 'curl' uses the network stack of container 'wireguard' which does not exist`, which was fixed by using the service network mode, which is a special network mode for docker compose to reference a container inside the compose.