### PR TITLE
Add kmod for zstd decompression support of kernel modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.13.6
 
 RUN apk add --no-cache \
-      openresolv iptables ip6tables iproute2 wireguard-tools \
+      kmod openresolv iptables ip6tables iproute2 wireguard-tools \
       findutils # Needed for find's -printf flag
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
For us that have zstd compressed kernel modules.

Solves this error:
```
modprobe: can't load module ip6_tables (kernel/net/ipv6/netfilter/ip6_tables.ko.zst): invalid module format
```