### PR TITLE
Pin to Alpine 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3
+FROM alpine:3.22
 
 RUN apk add --no-cache \
-	findutils openresolv iptables ip6tables iproute2 wireguard-tools
+    findutils openresolv iptables ip6tables iproute2 wireguard-tools
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
The version of openresolv in Alpine 3.23 breaks the Wireguard container with:

    resolvconf: signature mismatch: /etc/resolv.conf

For now, use an older version of openresolv until the community determines a better solution.

Example discussion:
https://www.linuxquestions.org/questions/slackware-14/openresolv-3-17-0-breaks-bringing-up-my-wireguard-vpn-4175751894/